### PR TITLE
Implement the `WarnDevelopers` behavior

### DIFF
--- a/src/fastapi_sunset/__init__.py
+++ b/src/fastapi_sunset/__init__.py
@@ -1,6 +1,12 @@
 """A lightweight and RFC 8594 compliant FastAPI middleware to facilitate endpoint deprecation."""
 
-from fastapi_sunset.behaviors import BasePeriodBehavior, DoNothing, RedirectUsers, RespondError
+from fastapi_sunset.behaviors import (
+    BasePeriodBehavior,
+    DoNothing,
+    RedirectUsers,
+    RespondError,
+    WarnDevelopers,
+)
 from fastapi_sunset.configuration import SunsetConfiguration
 
 __all__ = [
@@ -9,4 +15,5 @@ __all__ = [
     "RedirectUsers",
     "RespondError",
     "SunsetConfiguration",
+    "WarnDevelopers",
 ]

--- a/src/fastapi_sunset/behaviors/__init__.py
+++ b/src/fastapi_sunset/behaviors/__init__.py
@@ -2,5 +2,6 @@ from fastapi_sunset.behaviors.base import BasePeriodBehavior
 from fastapi_sunset.behaviors.do_nothing import DoNothing
 from fastapi_sunset.behaviors.error import RespondError
 from fastapi_sunset.behaviors.redirect import RedirectUsers
+from fastapi_sunset.behaviors.warn import WarnDevelopers
 
-__all__ = ["BasePeriodBehavior", "DoNothing", "RedirectUsers", "RespondError"]
+__all__ = ["BasePeriodBehavior", "DoNothing", "RedirectUsers", "RespondError", "WarnDevelopers"]

--- a/src/fastapi_sunset/behaviors/warn.py
+++ b/src/fastapi_sunset/behaviors/warn.py
@@ -1,0 +1,28 @@
+"""Behavior to warn developers during this period."""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+from fastapi_sunset.behaviors import BasePeriodBehavior
+
+if TYPE_CHECKING:
+    from fastapi_sunset.configuration import SunsetConfiguration
+
+
+class WarnDevelopers(BasePeriodBehavior):
+    """Warn developers (not users) during this period."""
+
+    message: str
+    """Message to be displayed during in the warning during this period.
+
+    Has access to the following format parameters from the `SunsetConfiguration`:
+        - `sunset_on`.
+        - `alternative_url`.
+    """
+    category: type[Warning] = FutureWarning
+
+    def behave_with(self, sunset_configuration: SunsetConfiguration) -> None:
+        """Emit a warning."""
+        warnings.warn(self.format_message(sunset_configuration), self.category, stacklevel=2)


### PR DESCRIPTION
# Summary
This PR implements a behavior that responds whatever the endpoint responds but issues a warning to developers so they can track endpoint usage.

# Testing
Again, just `uv run pytest` for now.