### PR TITLE
Make `SunsetConfiguration`'s defaults more sensible

### DIFF
--- a/src/fastapi_sunset/configuration.py
+++ b/src/fastapi_sunset/configuration.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 import logging
-from datetime import (
-    timedelta,  # noqa: TC003; pydantic needs this outside TYPE_CHECKING block to define the model
-)
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from pydantic import AwareDatetime, BaseModel
 
 from fastapi_sunset.behaviors import (
-    BasePeriodBehavior,  # noqa: TC001; pydantic needs this outside TYPE_CHECKING block to define the model
+    BasePeriodBehavior,  # pydantic needs this outside TYPE_CHECKING block to define the model
+    DoNothing,
+    RespondError,
+    WarnDevelopers,
 )
 
 if TYPE_CHECKING:
@@ -56,24 +57,32 @@ class SunsetConfiguration(BaseModel):
     alternative_url: str | None = None
     """URL to the new endpoint or documentation."""
 
-    upcoming_sunset_behavior: BasePeriodBehavior
+    upcoming_sunset_behavior: BasePeriodBehavior = DoNothing()
     """Behavior to take before the pre-sunset grace period."""
 
-    pre_sunset_grace_period_length: timedelta
+    pre_sunset_grace_period_length: timedelta = timedelta(days=14)
     """How long before `sunset_on` to assume the `pre_sunset_grace_period_behavior`.
 
     To disable this period, set to `timedelta(0)`.
     """
-    pre_sunset_grace_period_behavior: BasePeriodBehavior
+    pre_sunset_grace_period_behavior: BasePeriodBehavior = WarnDevelopers(
+        message="This endpoint will be deprecated on {sunset_on}. Please update your client.",
+        category=DeprecationWarning,
+    )
     """Behavior to take during the pre-sunset grace period."""
-    post_sunset_grace_period_length: timedelta
+    post_sunset_grace_period_length: timedelta = timedelta(days=14)
     """How long after `sunset_on` to assume the `post_sunset_grace_period_behavior`.
 
     To disable this period, set to `timedelta(0)`.
     """
-    post_sunset_grace_period_behavior: BasePeriodBehavior
+    post_sunset_grace_period_behavior: BasePeriodBehavior = WarnDevelopers(
+        message="This endpoint was deprecated on {sunset_on}. Please update your client.",
+        category=DeprecationWarning,
+    )
     """Behavior to take during the post-sunset grace period."""
-    sunset_period_behavior: BasePeriodBehavior
+    sunset_period_behavior: BasePeriodBehavior = RespondError(
+        message="This endpoint was deprecated on {sunset_on}. Please update your client."
+    )
     """Behavior to take after the post-sunset grace period ends."""
 
     def find_period_behavior(self, as_of: datetime) -> BasePeriodBehavior:


### PR DESCRIPTION
# Summary

This PR makes the defaults of the `SunsetConfiguration` defaults more sensible by implementing grace periods with warnings.

# Testing

`uv run pytest`