### PR TITLE
Rename `include_headres` to `include_headers`

### DIFF
--- a/src/fastapi_sunset/behaviors/base.py
+++ b/src/fastapi_sunset/behaviors/base.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class BasePeriodBehavior(BaseModel):
     """Do nothing special (i.e., continue running the endpoint as usual) during this period."""
 
-    include_headres: bool = True
+    include_headers: bool = True
 
     def format_message(self, sunset_configuration: SunsetConfiguration) -> str:
         """If the behavior has a `message`, format it with `sunset_on` and `alternative_url`.

--- a/tests/test_behaviors.py
+++ b/tests/test_behaviors.py
@@ -51,7 +51,7 @@ class TestBasePeriodBehavior(TestBehaviorBase):
         """Test that BasePeriodBehavior can be initialized."""
         behavior = BasePeriodBehavior()
         assert isinstance(behavior, BaseModel)
-        assert behavior.include_headres is True
+        assert behavior.include_headers is True
 
     def test_format_message_without_message_attribute(
         self, sunset_config: SunsetConfiguration
@@ -115,7 +115,7 @@ class TestDoNothingBehavior(TestBehaviorBase):
         """Test that BasePeriodBehavior can be initialized."""
         behavior = BasePeriodBehavior()
         assert isinstance(behavior, BaseModel)
-        assert behavior.include_headres is True
+        assert behavior.include_headers is True
 
     def test_inheritance(self, behavior: DoNothing) -> None:
         """Test that DoNothing inherits from BasePeriodBehavior."""

--- a/tests/test_sunset_configuration.py
+++ b/tests/test_sunset_configuration.py
@@ -262,21 +262,21 @@ class TestSunsetConfiguration:
 
         assert sunset_configuration.alternative_url is None
         assert isinstance(sunset_configuration.upcoming_sunset_behavior, DoNothing)
-        assert sunset_configuration.upcoming_sunset_behavior.include_headres
+        assert sunset_configuration.upcoming_sunset_behavior.include_headers
 
         assert sunset_configuration.pre_sunset_grace_period_length == timedelta(14)
         behavior = sunset_configuration.pre_sunset_grace_period_behavior
         assert isinstance(behavior, WarnDevelopers)
-        assert behavior.include_headres
+        assert behavior.include_headers
         assert behavior.category is DeprecationWarning
 
         assert sunset_configuration.post_sunset_grace_period_length == timedelta(14)
         behavior = sunset_configuration.post_sunset_grace_period_behavior
         assert isinstance(behavior, WarnDevelopers)
-        assert behavior.include_headres
+        assert behavior.include_headers
         assert behavior.category is DeprecationWarning
 
         behavior = sunset_configuration.sunset_period_behavior
         assert isinstance(behavior, RespondError)
-        assert behavior.include_headres
+        assert behavior.include_headers
         assert behavior.error_code == status.HTTP_410_GONE


### PR DESCRIPTION
# Summary

This PR fixes a typo in the `include_headers` property of `BasePeriodBehavior`, which was erroneously named `include_headres`.

# Testing

`uv run pytest`.