### PR TITLE
Implement `SunsetEndpointsMiddleware`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,5 +12,13 @@
             "console": "integratedTerminal",
             "justMyCode": true,
         },
+        {
+            "name": "Pytest: All Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+        },
     ],
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,5 @@ line-ending = "auto"
 addopts = [
     "--import-mode=importlib", # https://docs.pytest.org/en/stable/explanation/goodpractices.html#which-import-mode
 ]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,12 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
-dev = ["pre-commit>=4.1.0", "pytest>=8.3.4", "ruff>=0.9.7"]
+dev = [
+    "pre-commit>=4.1.0",
+    "pytest>=8.3.4",
+    "pytest-asyncio>=0.25.3",
+    "ruff>=0.9.7",
+]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ extend-ignore = [
     "D100",   # D100 - Module dostrings not required in test files.
     "D104",   # D104 - Package dostrings not required in test files.
     "ARG",    # ARG - Unused args are common in tests with mock patches and mock functions.
+    "SLF001", # Testig my own class demands private member access.
 ]
 
 "**/*/__init__.py" = [

--- a/src/fastapi_sunset/__init__.py
+++ b/src/fastapi_sunset/__init__.py
@@ -8,6 +8,7 @@ from fastapi_sunset.behaviors import (
     WarnDevelopers,
 )
 from fastapi_sunset.configuration import SunsetConfiguration
+from fastapi_sunset.sunset import SunsetEndpointsMiddleware
 
 __all__ = [
     "BasePeriodBehavior",
@@ -15,5 +16,6 @@ __all__ = [
     "RedirectUsers",
     "RespondError",
     "SunsetConfiguration",
+    "SunsetEndpointsMiddleware",
     "WarnDevelopers",
 ]

--- a/src/fastapi_sunset/sunset.py
+++ b/src/fastapi_sunset/sunset.py
@@ -1,0 +1,106 @@
+"""Implement a middleware to handle deprecation of endpoints."""
+
+from datetime import datetime, timezone
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.types import ASGIApp
+
+from fastapi_sunset.configuration import SunsetConfiguration
+
+
+def _make_headers(sunset_on: datetime, link: str | None) -> dict[str, str]:
+    """Create the Sunset and Link headers if necessary.
+
+    Args:
+        sunset_on (datetime): When the endpoint will be deprecated.
+        link (str | None): URL to the new endpoint or documentation. If None, won't include a `Link`
+            header. Defaults to None.
+
+    Returns:
+        dict[str, str]: The headers to include in the response.
+    """
+    headers = {"Sunset": sunset_on.strftime("%a, %d %b %Y %H:%M:%S GMT")}
+    if link:
+        headers["Link"] = f'<{link}>; rel="sunset"'
+    return headers
+
+
+class SunsetEndpointsMiddleware(BaseHTTPMiddleware):
+    """Handle deprecation of endpoints by adding a Sunset header and performing actions.
+
+    Args:
+        app (ASGIApp): The ASGI application to wrap.
+        **sunset_configurations (SunsetConfiguration): URL paths and their sunset configurations.
+            The path must match that of the `request.url.path`. See
+            `self.register_sunset_configuration` for details.
+    """
+
+    def __init__(self, app: ASGIApp, **sunset_configurations: SunsetConfiguration) -> None:
+        super().__init__(app)
+        self._sunset_registry: dict[str, SunsetConfiguration] = {}
+        self.register_sunset_configurations(**sunset_configurations)
+
+    def register_sunset_configuration(
+        self, endpoint_url: str, sunset_configuration: SunsetConfiguration
+    ) -> None:
+        """Register a sunset configuration to the middleware.
+
+        Args:
+            endpoint_url (str): The endpoint path to sunset. The path must match that of the
+                `request.url.path`.
+            sunset_configuration (SunsetConfiguration): The configuration to deprecate the given
+                `endpoint_url`.
+
+        Raises:
+            ValueError: If the `endpoint_url` is already registered.
+        """
+        if endpoint_url in self._sunset_registry:
+            msg = f"Endpoint {endpoint_url} already has a sunset configuration."
+            raise ValueError(msg)
+        self._sunset_registry[endpoint_url] = sunset_configuration
+
+    def register_sunset_configurations(self, **sunset_configurations: SunsetConfiguration) -> None:
+        """Register all the given sunset configurations to the middleware.
+
+        Args:
+            **sunset_configurations (SunsetConfiguration): Each key and value is passed to
+                `self.register_sunset_configuration` as `endpoint_url` and `sunset_configuration
+        """
+        for endpoint_url, sunset_configuration in sunset_configurations.items():
+            self.register_sunset_configuration(endpoint_url, sunset_configuration)
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        """Apply proper deprecation actions of the endpoint to the response where appropriate.
+
+        Args:
+            request (Request): The request being handled.
+            call_next (RequestResponseEndpoint): The callable to await to continue the chain and get
+                the response.
+
+        Returns:
+            Response: The response to the request with the proper headers set.
+        """
+        sunset_configuration = self._sunset_registry.get(request.url.path)
+        if sunset_configuration is None:
+            return await call_next(request)
+
+        now = datetime.now(tz=timezone.utc)
+        behavior = sunset_configuration.find_period_behavior(now)
+
+        sunset_headers = (
+            _make_headers(sunset_configuration.sunset_on, sunset_configuration.alternative_url)
+            if behavior.include_headers
+            else {}
+        )
+
+        outcome = behavior.behave_with(sunset_configuration)
+
+        if outcome is not None:  # Returned a response so we cut the chain short.
+            outcome.headers.update(sunset_headers)
+            return outcome
+
+        response = await call_next(request)
+        response.headers.update(sunset_headers)
+
+        return response

--- a/tests/test_sunset.py
+++ b/tests/test_sunset.py
@@ -1,0 +1,267 @@
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from typing import TypeVar
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import Request, Response, status
+from fastapi.responses import JSONResponse
+from starlette.types import ASGIApp
+
+from fastapi_sunset.behaviors.base import BasePeriodBehavior
+from fastapi_sunset.configuration import SunsetConfiguration
+from fastapi_sunset.sunset import SunsetEndpointsMiddleware, _make_headers
+
+T = TypeVar("T", bound=str | None)
+
+
+class TestMakeHeaders:
+    """Test the _make_headers function."""
+
+    @pytest.fixture
+    def sunset_on(self) -> datetime:
+        """Return a datetime object for the sunset date."""
+        return datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    def test_date_and_link(self, sunset_on: datetime) -> None:
+        """Test the headers when both a date and link are provided."""
+        headers = _make_headers(sunset_on, "https://new.example.com")
+
+        assert headers == {
+            "Sunset": "Mon, 01 Jan 2024 00:00:00 GMT",
+            "Link": '<https://new.example.com>; rel="sunset"',
+        }
+
+    def test_date_only(self, sunset_on: datetime) -> None:
+        """Test the headers when only a date is provided."""
+        headers = _make_headers(sunset_on, None)
+
+        assert headers == {"Sunset": "Mon, 01 Jan 2024 00:00:00 GMT"}
+
+    def test_no_date(self) -> None:
+        """Test the headers when you give a `null` date regardless of the link."""
+        with pytest.raises(AttributeError):
+            _make_headers(None, None)  # type: ignore[reportArgumentType]; this is what we're testing.
+
+        with pytest.raises(AttributeError):
+            _make_headers(None, "https://new.example.com")  # type: ignore[reportArgumentType]; this is what we're testing.
+
+
+class TestSunsetEndpointMiddlewareRegistry:
+    """Test the SunsetEndpointsMiddleware registry."""
+
+    @pytest.fixture
+    def mock_middleware(self) -> SunsetEndpointsMiddleware:
+        """Return a mock middleware instance with no configurations attached."""
+        return SunsetEndpointsMiddleware(Mock(spec=ASGIApp))
+
+    @pytest.fixture
+    def mock_sunset_configuration(self) -> SunsetConfiguration:
+        """Return a mock sunset configuration."""
+        sunset_configuration = Mock(spec=SunsetConfiguration)
+        sunset_configuration.sunset_on = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        sunset_configuration.alternative_url = "/api/v2/deprecated"
+        return sunset_configuration
+
+    def test_register_sunset_configuration(
+        self,
+        mock_middleware: SunsetEndpointsMiddleware,
+        mock_sunset_configuration: SunsetConfiguration,
+    ) -> None:
+        """Test that registering a sunset configuration works."""
+        mock_middleware.register_sunset_configuration("/test", mock_sunset_configuration)
+
+        assert "/test" in mock_middleware._sunset_registry
+        assert mock_middleware._sunset_registry["/test"] is mock_sunset_configuration
+
+    def test_register_duplicate_sunset_configuration(
+        self,
+        mock_middleware: SunsetEndpointsMiddleware,
+        mock_sunset_configuration: SunsetConfiguration,
+    ) -> None:
+        """Test that registering a duplicate sunset configuration raises an error."""
+        mock_middleware.register_sunset_configuration("/test", mock_sunset_configuration)
+
+        with pytest.raises(ValueError, match="Endpoint /test already has a sunset configuration."):
+            mock_middleware.register_sunset_configuration("/test", mock_sunset_configuration)
+
+    def test_register_sunset_configurations(
+        self,
+        mock_middleware: SunsetEndpointsMiddleware,
+        mock_sunset_configuration: SunsetConfiguration,
+    ) -> None:
+        """Test that registering multiple sunset configurations works."""
+        mock_middleware.register_sunset_configurations(
+            **{"/test1": mock_sunset_configuration, "/test2": mock_sunset_configuration}
+        )
+
+        assert "/test1" in mock_middleware._sunset_registry
+        assert "/test2" in mock_middleware._sunset_registry
+
+
+class TestSunsetEndpointMiddlewareDispatch:
+    """Test the dispatch method of the SunsetEndpointsMiddleware class."""
+
+    @pytest.fixture
+    def mock_request(self) -> Mock:
+        """Mock request object that simulates an API hit to /api/v1/deprecated."""
+        request = Mock(spec=Request)
+        request.url.path = "/api/v1/deprecated"
+        return request
+
+    @pytest.fixture
+    def default_response(self) -> Response:
+        """Return a default response."""
+        return JSONResponse(
+            content={"response_type": "default"},
+            status_code=status.HTTP_200_OK,
+            headers={"response_type": "default"},
+        )
+
+    @pytest.fixture
+    def mock_call_next(self, default_response: Response) -> AsyncMock:
+        """A mock `call_next` function that returns the default response.
+
+        Args:
+            default_response (Response): The default response to return when calling the returned
+                function.
+
+        Returns:
+            AsyncMock: The mock `call_next` callable, with spec
+                `Callable[[Request], Awaitable[Response]]`.
+        """
+        call_next = AsyncMock(spec=Callable[[Request], Awaitable[Response]])
+        call_next.return_value = default_response
+        return call_next
+
+    def _build_mock_sunset_configuration(
+        self, *, include_headers: bool = False
+    ) -> SunsetConfiguration:
+        """Build a Mock SunsetConfiguration instance.
+
+        Notes:
+            - `find_period_behavior` returns a Mock `BasePeriodBehavior` instance.
+                - It has `include_headers` set to the given value.
+                - Its `behave_with` method returns `None`.
+            - The `alternative_url` is set to "/api/v2/deprecated".
+            - The `sunset_on` is set to 2024-01-01T00:00:00+00:00.
+
+        Args:
+            include_headers (bool, optional): Whether the returned behavior includes headers or not.
+                Defaults to False.
+
+        Returns:
+            SunsetConfiguration: The mocked `SunsetConfiguration`.
+        """
+        sunset_config = Mock(spec=SunsetConfiguration)
+        behavior = Mock(spec=BasePeriodBehavior)
+        behavior.include_headers = include_headers
+        behavior.behave_with.return_value = None
+        sunset_config.find_period_behavior.return_value = behavior
+        sunset_config.sunset_on = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        sunset_config.alternative_url = "/api/v2/deprecated"
+        return sunset_config
+
+    @pytest.fixture
+    def mock_sunset_configuration_headers(self) -> SunsetConfiguration:
+        """Return a mock sunset configuration that includes sunset headers."""
+        return self._build_mock_sunset_configuration(include_headers=True)
+
+    @pytest.fixture
+    def mock_sunset_configuration_no_headers(self) -> SunsetConfiguration:
+        """Return a mock sunset configuration that includes no sunset headers."""
+        return self._build_mock_sunset_configuration(include_headers=False)
+
+    @pytest.fixture
+    def mock_middleware(self) -> SunsetEndpointsMiddleware:
+        """Return a mock middleware instance with no configurations attached."""
+        return SunsetEndpointsMiddleware(Mock(spec=ASGIApp))
+
+    @pytest.mark.asyncio
+    async def test_dispatch_unregistered_endpoint(
+        self,
+        mock_middleware: SunsetEndpointsMiddleware,
+        mock_sunset_configuration_headers: SunsetConfiguration,
+        mock_request: Mock,
+        mock_call_next: AsyncMock,
+        default_response: Response,
+    ) -> None:
+        """Ensure call_next is called and nothing else happens if the endpoint is not registered."""
+        mock_middleware.register_sunset_configuration(
+            "/api/v1/different_deprecated", mock_sunset_configuration_headers
+        )
+
+        response = await mock_middleware.dispatch(mock_request, mock_call_next)
+
+        assert mock_call_next.called
+        assert response is default_response
+        assert "Sunset" not in response.headers
+        assert "Link" not in response.headers
+
+    @pytest.mark.asyncio
+    async def test_dispatch_with_include_headers(
+        self,
+        mock_middleware: SunsetEndpointsMiddleware,
+        mock_sunset_configuration_headers: SunsetConfiguration,
+        mock_request: Mock,
+        mock_call_next: AsyncMock,
+        default_response: Response,
+    ) -> None:
+        """Ensure headers are added when behavior include headers."""
+        mock_middleware.register_sunset_configuration(
+            "/api/v1/deprecated", mock_sunset_configuration_headers
+        )
+
+        response = await mock_middleware.dispatch(mock_request, mock_call_next)
+
+        assert mock_call_next.called
+        assert response is default_response  # Because behave_with returns None.
+        assert "Sunset" in response.headers
+        assert "Link" in response.headers
+        assert response.headers["Sunset"] == "Mon, 01 Jan 2024 00:00:00 GMT"
+        assert response.headers["Link"] == '</api/v2/deprecated>; rel="sunset"'
+
+    @pytest.mark.asyncio
+    async def test_dispatch_without_include_headers(
+        self,
+        mock_middleware: SunsetEndpointsMiddleware,
+        mock_sunset_configuration_no_headers: SunsetConfiguration,
+        mock_request: Mock,
+        mock_call_next: AsyncMock,
+        default_response: Response,
+    ) -> None:
+        """Ensure headers are not added when behavior does not include headers."""
+        mock_middleware.register_sunset_configuration(
+            "/api/v1/deprecated", mock_sunset_configuration_no_headers
+        )
+        response = await mock_middleware.dispatch(mock_request, mock_call_next)
+
+        assert mock_call_next.called
+        assert response is default_response  # Because behave_with returns None.
+        assert "Sunset" not in response.headers
+        assert "Link" not in response.headers
+
+    @pytest.mark.asyncio
+    async def test_dispatch_behavior_returns_response(
+        self,
+        mock_middleware: SunsetEndpointsMiddleware,
+        mock_sunset_configuration_headers: SunsetConfiguration,
+        mock_request: Mock,
+        mock_call_next: AsyncMock,
+    ) -> None:
+        """Ensure call_next is not called when behavior responds."""
+        behavior = mock_sunset_configuration_headers.find_period_behavior.return_value
+        behavior_response = JSONResponse(
+            content={"message": "endpoint deprecated"}, status_code=410
+        )
+        behavior.behave_with.return_value = behavior_response
+        mock_sunset_configuration_headers.find_period_behavior.return_value = behavior
+
+        mock_middleware.register_sunset_configuration(
+            "/api/v1/deprecated", mock_sunset_configuration_headers
+        )
+
+        response = await mock_middleware.dispatch(mock_request, mock_call_next)
+
+        assert not mock_call_next.called
+        assert response is behavior_response

--- a/uv.lock
+++ b/uv.lock
@@ -89,6 +89,7 @@ dependencies = [
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -102,6 +103,7 @@ requires-dist = [
 dev = [
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "ruff", specifier = ">=0.9.7" },
 ]
 
@@ -297,6 +299,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a", size = 54239 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3", size = 19467 },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary

This PR builds upon the already merged components to implement the `SunsetEndpointsMiddleware`, which enables users to sunset FastAPI endpoints from a central location.

# Testing

`uv run pytest`